### PR TITLE
update support for popular mods in 1.10 (untested)

### DIFF
--- a/configs/Blank/INI/BiomesOPlenty.ini
+++ b/configs/Blank/INI/BiomesOPlenty.ini
@@ -7,7 +7,7 @@ Prefix: bopl
 Detect: BiomesOPlenty
 Description: A mod that adds a large collection of biomes to Minecraft.  Configuration by Reteo.
 
-; Default settings don't need to be added to individual sections.
+; Default settings do not need to be added to individual sections.
 [DEFAULT]
 Alternate Blocks: minecraft:lava
 Wireframe: no
@@ -19,39 +19,39 @@ Cloud Frequency: 0, 0, normal, base
 ; -- Individual Ores
 [Amethyst]
 Distribution Presets: Pipe Veins, Strategic Clouds, Vanilla
-Blocks: BiomesOPlenty:gemOre
+Blocks: BiomesOPlenty:gem_ore
 
 
 
 [Ruby]
 Distribution Presets: Pipe Veins, Strategic Clouds, Vanilla
-Blocks: BiomesOPlenty:gemOre:2
+Blocks: BiomesOPlenty:gem_ore:1
 
 
 [Peridot]
 Distribution Presets: Pipe Veins, Strategic Clouds, Vanilla
-Blocks: BiomesOPlenty:gemOre:4
+Blocks: BiomesOPlenty:gem_ore:2
 
 
 [Topaz]
 Distribution Presets: Pipe Veins, Strategic Clouds, Vanilla
-Blocks: BiomesOPlenty:gemOre:6
+Blocks: BiomesOPlenty:gem_ore:3
 
 
 [Tanzanite]
 Distribution Presets: Pipe Veins, Strategic Clouds, Vanilla
-Blocks: BiomesOPlenty:gemOre:8
+Blocks: BiomesOPlenty:gem_ore:4
 
 
 [Malachite]
 Distribution Presets: Pipe Veins, Strategic Clouds, Vanilla
-Blocks: BiomesOPlenty:gemOre:10
+Blocks: BiomesOPlenty:gem_ore:5
 
 [Sapphire]
 Distribution Presets: Pipe Veins, Strategic Clouds, Vanilla
-Blocks: BiomesOPlenty:gemOre:12
+Blocks: BiomesOPlenty:gem_ore:6
 
 
 [Amber]
 Distribution Presets: Pipe Veins, Strategic Clouds, Vanilla
-Blocks: BiomesOPlenty:gemOre:14
+Blocks: BiomesOPlenty:gem_ore:7

--- a/configs/Blank/INI/Forestry.ini
+++ b/configs/Blank/INI/Forestry.ini
@@ -4,10 +4,10 @@
 [Mod]
 Name: Forestry
 Prefix: frst
-Detect: Forestry
+Detect: forestry
 Description: A mod focused on breeding of trees and bees. Configuration by Reteo.
 
-; Default settings don't need to be added to individual sections.
+; Default settings do not need to be added to individual sections.
 [DEFAULT]
 Wireframe: no
 Bounding Box: no
@@ -19,16 +19,16 @@ Cloud Frequency: 0, 0, normal, base
 ; -- Individual Ores
 [Apatite]
 Distribution Presets: Sparse Veins, Strategic Clouds, Vanilla
-Blocks: Forestry:resources
+Blocks: forestry:resources
 
 
 
 [Copper]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: Forestry:resources:1
+Blocks: forestry:resources:1
 
 
 
 [Tin]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: Forestry:resources:2
+Blocks: forestry:resources:2

--- a/configs/Blank/INI/ImmersiveEngineering.ini
+++ b/configs/Blank/INI/ImmersiveEngineering.ini
@@ -9,10 +9,10 @@
 [Mod]
 Name: Immersive Engineering
 Prefix: ieng
-Detect: ImmersiveEngineering
+Detect: immersiveengineering
 Description: Configuration by Reteo.
 
-; Default settings don't need to be added to individual sections.
+; Default settings do not need to be added to individual sections.
 [DEFAULT]
 Wireframe: no
 Bounding Box: no
@@ -23,45 +23,45 @@ Cloud Frequency: 0, 0, normal, base
 ; -- Individual Ores
 [Copper]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: ImmersiveEngineering:ore:0
+Blocks: immersiveengineering:ore:0
 
 
 [Mountain Copper]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: ImmersiveEngineering:ore:0
+Blocks: immersiveengineering:ore:0
 
 [Bauxite]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: ImmersiveEngineering:ore:1
+Blocks: immersiveengineering:ore:1
 
 
 [Mountain Bauxite]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: ImmersiveEngineering:ore:1
+Blocks: immersiveengineering:ore:1
 
 [Lead]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: ImmersiveEngineering:ore:2
+Blocks: immersiveengineering:ore:2
 
 
 [Mountain Lead]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: ImmersiveEngineering:ore:2
+Blocks: immersiveengineering:ore:2
 
 [Silver]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: ImmersiveEngineering:ore:3
+Blocks: immersiveengineering:ore:3
 
 
 [Mountain Silver]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: ImmersiveEngineering:ore:3
+Blocks: immersiveengineering:ore:3
 
 [Nickel]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: ImmersiveEngineering:ore:4
+Blocks: immersiveengineering:ore:4
 
 
 [Mountain Nickel]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: ImmersiveEngineering:ore:4
+Blocks: immersiveengineering:ore:4

--- a/configs/Blank/INI/IndustrialCraft2.ini
+++ b/configs/Blank/INI/IndustrialCraft2.ini
@@ -7,7 +7,7 @@ Prefix: ic2
 Detect: IC2
 Description: Configuration by Reteo.
 
-; Default settings don't need to be added to individual sections.
+; Default settings do not need to be added to individual sections.
 [DEFAULT]
 Wireframe: no
 Bounding Box: no
@@ -18,36 +18,36 @@ Cloud Frequency: 0, 0, normal, base
 ; -- Individual Ores
 [Copper]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: IC2:blockOreCopper
+Blocks: IC2:resource:1
 
 
 [Mountain Copper]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: IC2:blockOreCopper
+Blocks: IC2:resource:1
 
 [Tin]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: IC2:blockOreTin
+Blocks: IC2:resource:3
 
 
 [Mountain Tin]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: IC2:blockOreTin
+Blocks: IC2:resource:3
 
 [Uranium]
 Distribution Presets: Sparse Veins, Strategic Clouds, Vanilla
-Blocks: IC2:blockOreUran
+Blocks: IC2:resource:4
 
 
 [Mountain Uranium]
 Distribution Presets: Sparse Veins, Strategic Clouds, Vanilla
-Blocks: IC2:blockOreUran
+Blocks: IC2:resource:4
 
 [Lead]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: IC2:blockOreLead
+Blocks: IC2:resource:2
 
 
 [Mountain Lead]
 Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: IC2:blockOreLead
+Blocks: IC2:resource:2

--- a/configs/Blank/INI/Railcraft.ini
+++ b/configs/Blank/INI/Railcraft.ini
@@ -4,10 +4,10 @@
 [Mod]
 Name: RailCraft
 Prefix: rlcr
-Detect: Railcraft
+Detect: railcraft
 Description: Expands the minecart system in Minecraft into a full-fledged train set. Configuration by Reteo.
 
-; Default settings don't need to be added to individual sections.
+; Default settings do not need to be added to individual sections.
 [DEFAULT]
 Wireframe: no
 Bounding Box: no
@@ -21,67 +21,67 @@ Cloud Frequency: 0, 0, normal, base
 ; --- Abyssal Geodes ---
 [Abyssal Ores]
 Distribution Presets: Geode
-Blocks: Railcraft:ore:2, Railcraft:ore:3, Railcraft:ore:4
-Alternate Blocks: Railcraft:cube:6
+Blocks: railcraft:ore:2, railcraft:ore:3, railcraft:ore:4
+Alternate Blocks: railcraft:generic:8
 Alternate Block Cleanup: yes
 
 
 [Poor Iron]
 Distribution Presets: Sparse Veins, Strategic Clouds, Vanilla
-Blocks: Railcraft:ore:7
+Blocks: railcraft:ore:7
 
 
 [Mountain Poor Iron]
 Distribution Presets: Sparse Veins, Strategic Clouds, Vanilla
-Blocks: Railcraft:ore:7
+Blocks: railcraft:ore:7
 
 [Poor Gold]
 Distribution Presets: Sparse Veins, Strategic Clouds, Vanilla
-Blocks: Railcraft:ore:8
+Blocks: railcraft:ore:8
 
 
 [Mountain Poor Gold]
 Distribution Presets: Sparse Veins, Strategic Clouds, Vanilla
-Blocks: Railcraft:ore:8
+Blocks: railcraft:ore:8
 
 [Poor Copper]
 Distribution Presets: Sparse Veins, Strategic Clouds, Vanilla
-Blocks: Railcraft:ore:9
+Blocks: railcraft:ore:9
 
 
 [Mountain Poor Copper]
 Distribution Presets: Sparse Veins, Strategic Clouds, Vanilla
-Blocks: Railcraft:ore:9
+Blocks: railcraft:ore:9
 
 [Poor Tin]
 Distribution Presets: Sparse Veins, Strategic Clouds, Vanilla
-Blocks: Railcraft:ore:10
+Blocks: railcraft:ore:10
 
 
 [Mountain Poor Tin]
 Distribution Presets: Sparse Veins, Strategic Clouds, Vanilla
-Blocks: Railcraft:ore:10
+Blocks: railcraft:ore:10
 
 [Poor Lead]
 Distribution Presets: Sparse Veins, Strategic Clouds, Vanilla
-Blocks: Railcraft:ore:11
+Blocks: railcraft:ore:11
 
 
 [Mountain Poor Lead]
 Distribution Presets: Sparse Veins, Strategic Clouds, Vanilla
-Blocks: Railcraft:ore:11
+Blocks: railcraft:ore:11
 
 [Sulfur]
 Distribution Presets: Pipe Veins, Strategic Clouds, Vanilla
-Blocks: Railcraft:ore
+Blocks: railcraft:ore
 
 
 [Saltpeter]
 Distribution Presets: Sparse Veins, Strategic Clouds, Vanilla
-Blocks: Railcraft:ore:1
+Blocks: railcraft:ore:1
 
 
 [Firestone]
 Distribution Presets: Small Deposits, Strategic Clouds, Vanilla
 Dimensions: -1
-Blocks: Railcraft:ore:5
+Blocks: railcraft:ore:5

--- a/configs/Blank/INI/TinkersConstruct.ini
+++ b/configs/Blank/INI/TinkersConstruct.ini
@@ -4,10 +4,10 @@
 [Mod]
 Name: Tinkers Construct
 Prefix: tico
-Detect: TConstruct
+Detect: tconstruct
 Description: A mod centering around tool manufacturing, the smelting of ores plays a large part.  This mod also includes ores that are embedded in gravel, rather than stone. Configuration by Reteo.
 
-; Default settings don't need to be added to individual sections.
+; Default settings do not need to be added to individual sections.
 [DEFAULT]
 Wireframe: no
 Bounding Box: no
@@ -16,90 +16,15 @@ Vein Motherlode Frequency: 0, 0, normal, base
 Cloud Frequency: 0, 0, normal, base
 
 ; -- Individual Ores
-[Copper]
-Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: TConstruct:SearedBrick:3
-
-
-[Mountain Copper]
-Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: TConstruct:SearedBrick:3
-
-[Tin]
-Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: TConstruct:SearedBrick:4
-
-
-[Mountain Tin]
-Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: TConstruct:SearedBrick:4
-
-[Aluminum]
-Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: TConstruct:SearedBrick:5
-
-
-[Mountain Aluminum]
-Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: TConstruct:SearedBrick:5
 
 [Cobalt]
 Distribution Presets: Small Deposits, Strategic Clouds, Vanilla
 Dimensions: -1
-Blocks: TConstruct:SearedBrick:1
+Blocks: tconstruct:ore
 
 
 
 [Ardite]
 Distribution Presets: Small Deposits, Strategic Clouds, Vanilla
 Dimensions: -1
-Blocks: TConstruct:SearedBrick:2
-
-
-
-[Iron Gravel]
-Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: TConstruct:GravelOre
-
-
-[Mountain Iron Gravel]
-Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: TConstruct:GravelOre
-
-[Gold Gravel]
-Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: TConstruct:GravelOre:1
-
-
-[Mountain Gold Gravel]
-Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: TConstruct:GravelOre:1
-
-[Copper Gravel]
-Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: TConstruct:GravelOre:2
-
-
-
-[Tin Gravel]
-Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: TConstruct:GravelOre:3
-
-
-[Mountain Tin Gravel]
-Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: TConstruct:GravelOre:3
-
-[Aluminum Gravel]
-Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: TConstruct:GravelOre:4
-
-
-[Mountain Aluminum Gravel]
-Distribution Presets: Layered Veins, Strategic Clouds, Vanilla
-Blocks: TConstruct:GravelOre:4
-
-[Cobalt Gravel]
-Distribution Presets: Small Deposits, Strategic Clouds, Vanilla
-Dimensions: -1
-Blocks: TConstruct:GravelOre:5
+Blocks: tconstruct:ore:1


### PR DESCRIPTION
Untested update for 1.10 versions of Tinker's Construct (only provides cobalt and ardite now), IC2, Forestry, Railcraft and Immersive Engineering. Just selected those because they seem popular. The main change is that mod and block IDs are now encouraged to be lower case. The TellMe mod makes this easy, as it introspects the ore dictionary to dump the metadata value.